### PR TITLE
Add profile customization module

### DIFF
--- a/rmrp-admin-panel/includes/profile-customization.php
+++ b/rmrp-admin-panel/includes/profile-customization.php
@@ -1,0 +1,23 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+add_action('wp_footer', function () {
+    if (!bp_is_user()) return;
+    $colors = get_option('rmrp_notification_colors', []);
+    ?>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var map = JSON.parse('<?php echo esc_js(wp_json_encode($colors)); ?>');
+            if (!map) return;
+            Object.keys(map).forEach(function(action) {
+                var color = map[action];
+                if (!color) return;
+                document.querySelectorAll('[data-bp-notification-action="' + action + '"]').forEach(function(el) {
+                    el.style.backgroundColor = color;
+                });
+            });
+        });
+    </script>
+    <?php
+});
+?>

--- a/rmrp-admin-panel/rmrp-admin-panel.php
+++ b/rmrp-admin-panel/rmrp-admin-panel.php
@@ -47,6 +47,7 @@ require_once plugin_dir_path(__FILE__) . 'includes/disciplinary-form.php';
 require_once plugin_dir_path(__FILE__) . 'includes/disciplinary-save.php';
 require_once plugin_dir_path(__FILE__) . 'includes/disciplinary-history.php';
 require_once plugin_dir_path(__FILE__) . 'includes/disciplinary-tab.php';
+require_once plugin_dir_path(__FILE__) . 'includes/profile-customization.php';
 
 // Добавление пунктов меню
 add_action('admin_menu', function () {


### PR DESCRIPTION
## Summary
- add `profile-customization.php` with footer script for notification colors
- require the new file in `rmrp-admin-panel.php`
- refine the script to run only on profile pages

## Testing
- `php -l rmrp-admin-panel/includes/profile-customization.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684eff569ee88331819795e9a74c77bb